### PR TITLE
Changed Indicator to validate unique name only in the Subgroup scope

### DIFF
--- a/app/models/concerns/slugable.rb
+++ b/app/models/concerns/slugable.rb
@@ -8,6 +8,10 @@ module Slugable
   end
 
   def set_slug
-    self.slug = name_en.downcase.gsub(/[[:space:]]/, '-')
+    if self.class == Indicator
+      self.slug = "#{subgroup.name_en.downcase.gsub(/[[:space:]]/, '-')}-#{name_en.downcase.gsub(/[[:space:]]/, '-')}"
+    else
+      self.slug = name_en.downcase.gsub(/[[:space:]]/, '-')
+    end
   end
 end

--- a/app/models/indicator.rb
+++ b/app/models/indicator.rb
@@ -4,7 +4,7 @@ class Indicator < ApplicationRecord
     include Slugable
 
     validates_uniqueness_of :by_default, scope: :subgroup_id, if: :by_default?
-    validates_uniqueness_of :name_en
+    validates_uniqueness_of :name_en, scope: :subgroup_id
     validates_presence_of :name_en
 
     belongs_to :subgroup


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/GECHINA-161

We want same name for different indicators in different subgroups. We have the case of subgroup with name "Population" and indicator "Population" and also subgroup "Demographic" with indicator "Population".

- Change Indicator to validate unique name only in the Subgroup scope.
- Change set_slug to add the subgroup name in the slug for indicators.