### PR TITLE
Replaced underscores by dashes in the recover pass url

### DIFF
--- a/app/controllers/api/v1/users.rb
+++ b/app/controllers/api/v1/users.rb
@@ -100,7 +100,7 @@ module API
 				params do
 					requires :email, type: String, desc: "email of the user"
 				end
-				get "/recover_password_token" do
+				get "/recover-password-token" do
 					user = User.find_by(email: params["email"].downcase)
 					if user
 						UsermailerMailer.restore_password_email(user, user.recover_password_token).deliver_later

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe API::V1::Users do
     context 'whit the email of an existing user' do
       it 'returns 201' do
         params = { 'email': user.email }
-        get "/api/v1/users/recover_password_token", params, as: :json
+        get "/api/v1/users/recover-password-token", params, as: :json
 
         expect(last_response.status).to eq 200        
       end
@@ -144,7 +144,7 @@ RSpec.describe API::V1::Users do
         params = { 'email': user.email }
 
         expect {
-          get "/api/v1/users/recover_password_token", params, as: :json 
+          get "/api/v1/users/recover-password-token", params, as: :json 
         }.to have_enqueued_job(ActionMailer::MailDeliveryJob)     
       end
     end
@@ -152,7 +152,7 @@ RSpec.describe API::V1::Users do
     context 'whit an invalid email' do
       it 'returns 406' do
         params = { 'email': 'invalid@email.com' }
-        get "/api/v1/users/recover_password_token", params, as: :json
+        get "/api/v1/users/recover-password-token", params, as: :json
 
         expect(last_response.status).to eq 406        
       end
@@ -161,7 +161,7 @@ RSpec.describe API::V1::Users do
         params = { 'email': 'invalid@email.com' }
 
         expect {
-          get "/api/v1/users/recover_password_token", params, as: :json 
+          get "/api/v1/users/recover-password-token", params, as: :json 
         }.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)     
       end
     end


### PR DESCRIPTION
Not too much to comment here. I have changed those underscores to fit conventions.