### PR TITLE
Changes Geometries tables to add UUID and geomtry type instead of geography

### DIFF
--- a/app/models/geometry_polygons_importer.rb
+++ b/app/models/geometry_polygons_importer.rb
@@ -15,7 +15,8 @@ class GeometryPolygonsImporter
         region_type: properties['region_type']&.downcase&.split(' ')&.join('_')&.to_sym
       )
       new_geometry = GeometryPolygon.create(region: region, geometry: RGeo::GeoJSON.decode(row_data).geometry)
-      puts "new geometry created with id: #{new_geometry.id} for #{region.name}"
+      puts "new geometry created with id: #{new_geometry.id} for #{new_geometry.region.name}"
+      puts  "polygons count >> #{GeometryPolygon.count}"
     end
     puts "polygons count >> #{GeometryPolygon.count}"
   end

--- a/db/migrate/20211006105232_change_geometry_to_geometry_instead_of_geography.rb
+++ b/db/migrate/20211006105232_change_geometry_to_geometry_instead_of_geography.rb
@@ -1,0 +1,8 @@
+class ChangeGeometryToGeometryInsteadOfGeography < ActiveRecord::Migration[6.1]
+  def change
+    change_table :geometry_polygons do |t|
+      remove_column :geometry_polygons, :geometry
+      add_column :geometry_polygons, :geometry, :geometry, limit: {srid: 0, type: 'geometry'}
+    end
+  end
+end

--- a/db/migrate/20211006113046_change_region_id_from_bigint_to_uui_din_geometry_polygons.rb
+++ b/db/migrate/20211006113046_change_region_id_from_bigint_to_uui_din_geometry_polygons.rb
@@ -1,0 +1,6 @@
+class ChangeRegionIdFromBigintToUuiDinGeometryPolygons < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :geometry_polygons, :region_id
+    add_column :geometry_polygons, :region_id, :uuid
+  end
+end

--- a/db/migrate/20211006121350_change_geometry_points_to_geometry_instead_of_geography.rb
+++ b/db/migrate/20211006121350_change_geometry_points_to_geometry_instead_of_geography.rb
@@ -1,0 +1,8 @@
+class ChangeGeometryPointsToGeometryInsteadOfGeography < ActiveRecord::Migration[6.1]
+  def change
+    change_table :geometry_points do |t|
+      remove_column :geometry_points, :geometry
+      add_column :geometry_points, :geometry, :geometry, limit: {srid: 0, type: 'geometry'}
+    end
+  end
+end

--- a/db/migrate/20211006121500_change_region_id_from_bigint_to_uui_din_geometry_points.rb
+++ b/db/migrate/20211006121500_change_region_id_from_bigint_to_uui_din_geometry_points.rb
@@ -1,0 +1,6 @@
+class ChangeRegionIdFromBigintToUuiDinGeometryPoints < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :geometry_points, :region_id
+    add_column :geometry_points, :region_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_03_095820) do
+ActiveRecord::Schema.define(version: 2021_10_06_113046) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -90,11 +90,10 @@ ActiveRecord::Schema.define(version: 2021_10_03_095820) do
   end
 
   create_table "geometry_polygons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.bigint "region_id"
-    t.geography "geometry", limit: {:srid=>4326, :type=>"geometry", :geographic=>true}
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["region_id"], name: "index_geometry_polygons_on_region_id"
+    t.geometry "geometry", limit: {:srid=>0, :type=>"geometry"}
+    t.uuid "region_id"
   end
 
   create_table "geometry_polygons_import_attempts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_06_113046) do
+ActiveRecord::Schema.define(version: 2021_10_06_121500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -72,11 +72,10 @@ ActiveRecord::Schema.define(version: 2021_10_06_113046) do
   end
 
   create_table "geometry_points", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.bigint "region_id"
-    t.geography "geometry", limit: {:srid=>4326, :type=>"geometry", :geographic=>true}
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["region_id"], name: "index_geometry_points_on_region_id"
+    t.geometry "geometry", limit: {:srid=>0, :type=>"geometry"}
+    t.uuid "region_id"
   end
 
   create_table "geometry_points_import_attempts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
Here we are solving a few issues in one shot:

- After importing and successfully creating our geometries they were not retrieved because LinearRing Test was failing. It is solved by changing from geography to geometry.
- In the same process the region's relationship validation was passing but not saved to the DB because a mismatch in the column type that should be UUID instead of bigint. 